### PR TITLE
ENH: Add an argument to specify the ITK branch to fetch .clang-format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,7 @@ RUN apt-get update && apt-get install -y \
   wget \
   && cd /usr/bin && ln -s clang-format-8 clang-format
 
-RUN wget https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/master/Utilities/Maintenance/clang-format.bash \
-  && chmod +x ./clang-format.bash
-
-RUN wget https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/master/.clang-format \
-  && mv ./.clang-format /ITK.clang-format
-
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,12 @@ inputs:
   error-message:
     description: 'Error message when style changes are required.'
     default: 'Code is inconsistent with ITK Coding Style.'
+  itk-branch:
+    description: 'The Git branch of the ITK repository to fetch .clang-format from.'
+    default: 'master'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.error-message }}
+    - ${{ inputs.itk-branch }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,15 +3,22 @@
 set -euo pipefail
 
 error_message="$1"
+itk_branch="$2"
 
 git config --global --add safe.directory /github/workspace
 
 cd "$GITHUB_WORKSPACE"
 
+# Fetch the .clang-format file from the specified branch
+wget https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/${itk_branch}/.clang-format -O /ITK.clang-format
+
+wget https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/${itk_branch}/Utilities/Maintenance/clang-format.bash
+chmod +x ./clang-format.bash
+
 if ! test -f ./.clang-format; then
   cp /ITK.clang-format ./.clang-format
 fi
-/clang-format.bash --tracked
+./clang-format.bash --tracked
 if ! git diff-index --diff-filter=M --quiet HEAD -- ':!.clang-format'; then
   echo "::error ::${error_message}"
   echo ""


### PR DESCRIPTION
ITK 6 has a newer .clang-format style file for the latest clang-format.
