### PR TITLE
ENH: Bump `clang` version to 19.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 COPY LICENSE README.md /
 
 RUN apt-get update && apt-get install -y \
-  clang-format-8 \
+  clang-format-19.1.4 \
   git \
   wget \
   && cd /usr/bin && ln -s clang-format-8 clang-format


### PR DESCRIPTION
Bump `clang` version to 19.1.4: the version required by ITK was updated to 19.1.4 on Dec 5, 2024:
https://github.com/InsightSoftwareConsortium/ITK/pull/5015/commits/26b683ac9fca0b4e0a949b031eef64d201fc2bfe

Fixes:
```
clang-format version 19.1.x is required
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/actions/runs/12656100968/job/35267917218#step:5:29