### PR TITLE
BUG: Set default itk-branch to release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 'Code is inconsistent with ITK Coding Style.'
   itk-branch:
     description: 'The Git branch of the ITK repository to fetch .clang-format from.'
-    default: 'master'
+    default: 'release'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
ITK `master` has a number of clang-format style changes and may make
other changes. Enable repositories, e.g. remote modules, examples, etc.,
to opt-into newer ITK style via their GitHub Action configuration as
they update via the GitHub Action configuration.
