### PR TITLE
clang format itk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,12 @@
-FROM ubuntu:24.04
+FROM ubuntu:18.04
 
 COPY LICENSE README.md /
 
 RUN apt-get update && apt-get install -y \
+  clang-format-8 \
   git \
   wget \
-  lsb-release \
-  software-properties-common \
-  gnupg \
-  && apt-get clean
-
-# Download latest .deb packages from llvm.
-# See https://apt.llvm.org/ for instructions.
-RUN wget https://apt.llvm.org/llvm.sh \
-    && chmod +x llvm.sh \
-    && ./llvm.sh 19 \
-    && apt-get install -y clang-format-19 \
-    && apt-get clean
-
-# The following is a workaround to allow other scripts
-# that were hard-coded to use the unversioned clang-format
-# binary to continue to work.
-RUN cd /usr/bin && rm -rf clang-format && ln -s clang-format-19 clang-format
+  && cd /usr/bin && ln -s clang-format-8 clang-format
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY LICENSE README.md /
 
 RUN apt-get update && apt-get install -y \
   clang-format-8 \
+  curl \
   git \
   wget \
   && cd /usr/bin && ln -s clang-format-8 clang-format

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,18 @@ cd "$GITHUB_WORKSPACE"
 # Fetch the .clang-format file from the specified branch
 wget https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/${itk_branch}/.clang-format -O /ITK.clang-format
 
+if test $itk_branch = "master" -o $itk_branch = "main"; then
+  # Use the same version of clang-format as used by ITK with its configuration
+  wget https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/${itk_branch}/.pre-commit-config.yaml -O ./ITK.pre-commit-config.yaml
+  clang_format_version=$(grep -A 1 "mirrors-clang-format" ./ITK.pre-commit-config.yaml | tail -n 1 | cut -d: -f2 | tr -d ' v')
+  curl -fsSL https://pixi.sh/install.sh | bash
+  export PATH=$HOME/.pixi/bin:$PATH
+  pixi init
+  pixi add python
+  pixi add --pypi clang-format==$clang_format_version
+  export PATH=$PWD/.pixi/envs/default/bin:$PATH
+fi
+
 wget https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/${itk_branch}/Utilities/Maintenance/clang-format.bash
 chmod +x ./clang-format.bash
 


### PR DESCRIPTION
- BUG: Revert "ENH: Update to Ubuntu 24.04 and clang-format-19"
- ENH: Fetch the same version of clang-format as ITK
