### PR TITLE
ENH: The clang-version used extracted from master

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 'Code is inconsistent with ITK Coding Style.'
   itk-branch:
     description: 'The Git branch of the ITK repository to fetch .clang-format from.'
-    default: 'release'
+    default: 'v6.0a02'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
The release branch provides a clang-format.bash script that is too old.