### PR TITLE
Missing curl command in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY LICENSE README.md /
 RUN apt-get update && apt-get install -y \
   git \
   wget \
+  curl \
   lsb-release \
   software-properties-common \
   gnupg \


### PR DESCRIPTION
BUG: Missing curl command needed by entrypoint.sh script.
