### PR TITLE
Revert "ENH: Update to ubuntu 24.04 and clang-format-19"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,18 @@
-FROM ubuntu:24.04
+FROM ubuntu:18.04
 
 COPY LICENSE README.md /
 
 RUN apt-get update && apt-get install -y \
+  clang-format-8 \
+  curl \
   git \
   wget \
-  curl \
-  lsb-release \
-  software-properties-common \
-  gnupg \
   && apt-get clean
-
-# Download latest .deb packages from llvm.
-# See https://apt.llvm.org/ for instructions.
-RUN wget https://apt.llvm.org/llvm.sh \
-    && chmod +x llvm.sh \
-    && ./llvm.sh 19 \
-    && apt-get update \
-    && apt-get install -y clang-format-19 \
-    && apt-get clean
 
 # The following is a workaround to allow other scripts
 # that were hard-coded to use the unversioned clang-format
 # binary to continue to work.
-RUN cd /usr/bin && rm -rf clang-format && ln -s clang-format-19 clang-format
+RUN cd /usr/bin && ln -s clang-format-8 clang-format
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
This reverts commit c83c169b1e4875db1f4fc4376357be0d8b009ce1.

Newer clang-format, e.g. clang-format>=19 for ITK>=6 fetches the version that ITK uses via pixi.

ITK 5 formatting uses clang-format-8.