### PR TITLE
BUG: Fix path to clang-format for ITK 6 versions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,7 @@ if test $itk_branch = "master" -o $itk_branch = "main"; then
   pixi add python
   pixi add --pypi clang-format==$clang_format_version
   export PATH=$PWD/.pixi/envs/default/bin:$PATH
+  export PATH=/.pixi/envs/default/bin:$PATH
 fi
 
 wget https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/${itk_branch}/Utilities/Maintenance/clang-format.bash


### PR DESCRIPTION
Add installation path for newer clang-format for ITK 6, currently version 19, higher versions as upgrades occur.

Addresses:

  + ./clang-format.bash --tracked clang-format version 19.1.x is required

  https://github.com/cyrilmory/CyrilsRTK/actions/runs/13830719084/job/38694200868