### PR TITLE
ENH: Use clang-format version and .clang-format from ITK master by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 'Code is inconsistent with ITK Coding Style.'
   itk-branch:
     description: 'The Git branch of the ITK repository to fetch .clang-format from.'
-    default: 'v6.0a02'
+    default: 'master'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
The latest version.
