### PR TITLE
BUG: Fix exported pixi binary path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,7 @@ if test $itk_branch != "release-5.4" -a $itk_branch != "release"; then
   pixi init ..
   pixi add python
   pixi add --pypi clang-format==$clang_format_version
+  export PATH=$PWD/../.pixi/envs/default/bin:$PATH
   export PATH=$PWD/.pixi/envs/default/bin:$PATH
   export PATH=/.pixi/envs/default/bin:$PATH
 fi


### PR DESCRIPTION
I'm not sure what was the aim of #18 but it didn't work out for me, see e.g.
https://github.com/RTKConsortium/ITKCudaCommon/actions/runs/13853478401
This fix fixes the problem as demonstrated in 
https://github.com/RTKConsortium/ITKCudaCommon/actions/runs/13853459789